### PR TITLE
Fix compile errors on Linux

### DIFF
--- a/src/my_types.h
+++ b/src/my_types.h
@@ -228,7 +228,7 @@ typedef struct _stats_t
   cl_uint  class_number;              /* the number of the last processed class */
   cl_uint  grid_count;                /* number of grids processed in the last processed class */
   cl_ulong class_time;                /* time (in ms) needed to process the last processed class */
-  cl_ulong bit_level_time;            /* time (in ms) since the bitlevel was started */
+  unsigned long long bit_level_time;  /* time (in ms) since the bitlevel was started */
   cl_ulong cpu_wait_time;             /* time (ms) CPU was waiting for the GPU */
   float    cpu_wait;                  /* percentage CPU was waiting for the GPU */
   cl_uint  output_counter;            /* count how often the status line was written since last headline */

--- a/src/read_config.c
+++ b/src/read_config.c
@@ -18,11 +18,9 @@ along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include <stdio.h>
-#ifdef _WIN32
 #include <string.h>
+#ifdef _WIN32
 #define strcasecmp _stricmp
-#else // assuming POSIX or BSD compliant system
-#include <strings.h>
 #endif
 #include <errno.h>
 #if defined BUILD_OPENCL


### PR DESCRIPTION
Change type of `bit_level_time` to match the functions that process it.

Include `string.h` unconditionally. Don't include `strings.h`.

---

Since the master branch of `brubsby/mfakto` is used (very unusually) as a PR branch, this PR doesn't have to be applied. Perhaps it should be integrated into the PR to avoid creating compile issues in any commit.

I would also suggest having separate branches and separate PRs for every category of changes (bug fixes, spelling, versioning etc).